### PR TITLE
Fixes Fact method resolution order for __or__

### DIFF
--- a/py_rete/fact.py
+++ b/py_rete/fact.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Optional
 
 
-class Fact(dict, ComposableCond):
+class Fact(ComposableCond, dict):
     """
     A dictionary class that decomposes into individual conditions or wmes
     depending on the context.


### PR DESCRIPTION
The unit test tests/test_basic.py::test_readme_productions was failing.  This change allows the mixin to be earlier in the method resolution order so that `__or__` is chosen from ComposableCond instead of dict.